### PR TITLE
Fix PDF path to output directly to _build/html

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,15 +96,14 @@ jobs:
       - name: Build HTML Assets
         run: myst build --html
 
-      # Step 10: Copy PDF to HTML build directory for deployment
-      - name: Copy PDF to build
+      # Step 10: Verify PDF was generated
+      - name: Check PDF exists
         run: |
-          mkdir -p ./_build/html/exports
-          if [ -f ./exports/ModelingWithPhysics.pdf ]; then
-            cp ./exports/ModelingWithPhysics.pdf ./_build/html/exports/
-            echo "PDF copied successfully"
+          if [ -f ./_build/html/ModelingWithPhysics.pdf ]; then
+            echo "PDF generated successfully"
+            ls -lh ./_build/html/ModelingWithPhysics.pdf
           else
-            echo "Warning: PDF file not found, skipping copy"
+            echo "Warning: PDF was not generated"
           fi
 
       # Step 11: Upload the built HTML files as an artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # MyST build outputs
 _build
 
-# Generated PDF exports (built by CI)
-exports/*.pdf
+# Generated chapter exports (built by CI)
 chapters/exports/

--- a/myst.yml
+++ b/myst.yml
@@ -78,7 +78,7 @@ project:
         - ./chapters/24Calculus.md
         - ./chapters/25VisualPython.md
         - ./chapters/26Labs.md
-      output: ./exports/ModelingWithPhysics.pdf
+      output: ./_build/html/ModelingWithPhysics.pdf
   downloads:
     - id: ModelingWithPhysics-export
       title: Download PDF
@@ -97,7 +97,7 @@ site:
   nav: []
   actions:
     - title: Download PDF
-      url: /exports/ModelingWithPhysics.pdf
+      url: ModelingWithPhysics.pdf
   domains: []
 #html:
   


### PR DESCRIPTION
- Output PDF directly to _build/html/ModelingWithPhysics.pdf instead of separate exports folder
- Update action URL to relative path (ModelingWithPhysics.pdf)
- Remove unnecessary copy step from workflow
- PDF will now be at site root: /PhysicsArtOfModeling/ModelingWithPhysics.pdf